### PR TITLE
Fix "could not find array type for data" issue

### DIFF
--- a/database/store.go
+++ b/database/store.go
@@ -108,7 +108,7 @@ func (s *Store) queryTables(schema []string) ([]columnRow, error) {
 					kcu.table_name   as "table_name",
 					kcu.column_name  as "column_name",
 					array_agg((
-						select constraint_type 
+						select constraint_type::text 
 						from information_schema.table_constraints tc 
 						where tc.constraint_name = kcu.constraint_name 
 							and tc.constraint_schema = kcu.constraint_schema 


### PR DESCRIPTION
On some of my projects I faced with such panic exception:

```
panic: getting table info error: ERROR #42704 could not find array type for data type information_schema.character_data
```