### PR TITLE
Changed template_model to generate separated Columns and Tables structs

### DIFF
--- a/generator/template_model.go
+++ b/generator/template_model.go
@@ -7,32 +7,38 @@ import ({{range .Imports}}
     "{{.}}"{{end}}
 ){{end}}
 
-var Columns = struct { {{range .Models}}
-	{{.StructName}} struct{ 
+{{range .Models}}
+	type Columns{{.StructName}} struct{ 
 		{{range $i, $e := .Columns}}{{if $i}}, {{end}}{{.FieldName}}{{end}} string{{if .HasRelations}}
 
 		{{range $i, $e := .Relations}}{{if $i}}, {{end}}{{.FieldName}}{{end}} string{{end}}
-	}{{end}}
-}{ {{range .Models}}
-	{{.StructName}}: struct { 
-		{{range $i, $e := .Columns}}{{if $i}}, {{end}}{{.FieldName}}{{end}} string{{if .HasRelations}}
+	}
+{{end}}
 
-		{{range $i, $e := .Relations}}{{if $i}}, {{end}}{{.FieldName}}{{end}} string{{end}}
-	}{ {{range .Columns}}
+type ColumnsSt struct { {{range .Models}}
+	{{.StructName}} Columns{{.StructName}}{{end}}
+}
+
+var Columns = ColumnsSt{ {{range .Models}}
+	{{.StructName}}: Columns{{.StructName}}{ {{range .Columns}}
 		{{.FieldName}}: "{{.FieldDBName}}",{{end}}{{if .HasRelations}}
 		{{range .Relations}}
 		{{.FieldName}}: "{{.FieldName}}",{{end}}{{end}}
 	},{{end}}
 }
 
-var Tables = struct { {{range .Models}}
-	{{.StructName}} struct {
-		Name{{if .WithAlias}}, Alias{{end}} string
-	}{{end}}
-}{ {{range .Models}}
-	{{.StructName}}: struct {
-		Name{{if .WithAlias}}, Alias{{end}} string
-	}{ 
+{{range .Models}}
+type Table{{.StructName}} struct {
+	Name{{if .WithAlias}}, Alias{{end}} string
+}
+{{end}}
+
+type TablesSt struct { {{range .Models}}
+		{{.StructName}} Table{{.StructName}}{{end}}
+}
+
+var Tables = TablesSt { {{range .Models}}
+	{{.StructName}}: Table{{.StructName}}{ 
 		Name: "{{.TableName}}"{{if .WithAlias}},
 		Alias: "{{.TableAlias}}",{{end}}
 	},{{end}}


### PR DESCRIPTION
I've edited `template_model.go` to generate separated structs Columns and Tables structs.

The case is that I'm using this structs to extend some models like this:

`genna_models.go`
```
type ColumnsImage struct {
	ID, ParentID string

	Parent string
}

type ColumnsSt struct {
	Image ColumnsImage
}

var Columns = ColumnsSt{
	Image: ColumnsImage{
		ID:        "id",
		ParentID:  "parent_id",
		Parent: "Parent",
	},

```

`my_models.go`
```
type columnsImage struct {
	gennaModels.ColumnsImage

	Previews string \\ I'm adding this Relation name to have HasMany Relation
}

type ColumnsSt struct {
	gennaModels.ColumnsSt
	Image columnsImage
}

var Columns = ColumnsSt{
	ColumnsSt: gennaModels.Columns,
	Image: columnsImage{
		ColumnsImage: gennaModels.Columns.Image,
		Previews: "Previews",
	},
}
```

I'm adding this "Previews" Relation name to have HasMany Relation