### PR TITLE
Update template.go

### DIFF
--- a/generators/model/template.go
+++ b/generators/model/template.go
@@ -34,7 +34,7 @@ var Tables = struct { {{range .Entities}}
 	{{.GoName}}: struct {
 		Name{{if not .NoAlias}}, Alias{{end}} string
 	}{ 
-		Name: "{{.PGFullName}}"{{if not .NoAlias}},
+		Name: "{{.PGFullName}}",{{if not .NoAlias}}
 		Alias: "{{.Alias}}",{{end}}
 	},{{end}}
 }


### PR DESCRIPTION
It seems that the template of struct Tables is missing a comma when genna model command is invoked with -w flag.
So moving the comma , before the "if not .NoAlias" expression