### PR TITLE
Update search generator. Change pg.F to pg.Ident

### DIFF
--- a/generators/search/template.go
+++ b/generators/search/template.go
@@ -27,7 +27,11 @@ func (s *search) apply(query *orm.Query) {
 }
 
 func (s *search) where(query *orm.Query, table, field string, value interface{}) {
+	{{if eq .GoPGVer "/v9"}}
+	query.Where(condition, pg.Ident(table), pg.Ident(field), value)
+	{{else}}
 	query.Where(condition, pg.F(table), pg.F(field), value)
+	{{end}}
 }
 
 func (s *search) WithApply(a applier) {


### PR DESCRIPTION
According to v9 CHANGELOG
- `types.F` and `pg.F` are deprecated in favor of `pg.Ident`.

https://github.com/go-pg/pg/commit/9ab62c0f9c17851e2926c019d0262f198576930e#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR15