### PR TITLE
Fix BYTEA

### DIFF
--- a/generators/model/generator_test.go
+++ b/generators/model/generator_test.go
@@ -33,7 +33,7 @@ func TestGenerator_Generate(t *testing.T) {
 	}
 
 	if string(generated) != string(check) {
-		t.Errorf("generated not mathed with check")
+		t.Errorf("generated does not match with check")
 		return
 	}
 }

--- a/generators/model/generator_test.output
+++ b/generators/model/generator_test.output
@@ -7,7 +7,7 @@ var Columns = struct {
 		ID, Name string
 	}
 	User struct {
-		ID, Email, Activated, Name, CountryID string
+		ID, Email, Activated, Name, CountryID, Avatar, AvatarAlt, ApiKeys string
 
 		Country string
 	}
@@ -22,7 +22,7 @@ var Columns = struct {
 		Name: "name",
 	},
 	User: struct {
-		ID, Email, Activated, Name, CountryID string
+		ID, Email, Activated, Name, CountryID, Avatar, AvatarAlt, ApiKeys string
 
 		Country string
 	}{
@@ -31,6 +31,9 @@ var Columns = struct {
 		Activated: "activated",
 		Name:      "name",
 		CountryID: "countryId",
+		Avatar:    "avatar",
+		AvatarAlt: "avatarAlt",
+		ApiKeys:   "apiKeys",
 
 		Country: "Country",
 	},
@@ -84,11 +87,14 @@ type Project struct {
 type User struct {
 	tableName struct{} `sql:"users,alias:t" pg:",discard_unknown_columns"`
 
-	ID        int     `sql:"userId,pk"`
-	Email     string  `sql:"email,notnull"`
-	Activated bool    `sql:"activated,notnull"`
-	Name      *string `sql:"name"`
-	CountryID *int    `sql:"countryId"`
+	ID        int      `sql:"userId,pk"`
+	Email     string   `sql:"email,notnull"`
+	Activated bool     `sql:"activated,notnull"`
+	Name      *string  `sql:"name"`
+	CountryID *int     `sql:"countryId"`
+	Avatar    []byte   `sql:"avatar,notnull"`
+	AvatarAlt []byte   `sql:"avatarAlt"`
+	ApiKeys   [][]byte `sql:"apiKeys,array"`
 
 	Country *GeoCountry `pg:"fk:countryId"`
 }

--- a/generators/named/generator_test.go
+++ b/generators/named/generator_test.go
@@ -36,7 +36,7 @@ func TestGenerator_Generate(t *testing.T) {
 	}
 
 	if string(generated) != string(check) {
-		t.Errorf("generated not mathed with check")
+		t.Errorf("generated does not match with check")
 		return
 	}
 }

--- a/generators/named/generator_test.output
+++ b/generators/named/generator_test.output
@@ -7,8 +7,8 @@ type ColumnsProject struct {
 }
 
 type ColumnsUser struct {
-	ID, Email, Activated, Name, CountryID string
-	Country                               string
+	ID, Email, Activated, Name, CountryID, Avatar, AvatarAlt, ApiKeys string
+	Country                                                           string
 }
 
 type ColumnsGeoCountry struct {
@@ -32,6 +32,9 @@ var Columns = ColumnsSt{
 		Activated: "activated",
 		Name:      "name",
 		CountryID: "countryId",
+		Avatar:    "avatar",
+		AvatarAlt: "avatarAlt",
+		ApiKeys:   "apiKeys",
 
 		Country: "Country",
 	},
@@ -85,11 +88,14 @@ type Project struct {
 type User struct {
 	tableName struct{} `sql:"users,alias:t" pg:",discard_unknown_columns"`
 
-	ID        int     `sql:"userId,pk"`
-	Email     string  `sql:"email,notnull"`
-	Activated bool    `sql:"activated,notnull"`
-	Name      *string `sql:"name"`
-	CountryID *int    `sql:"countryId"`
+	ID        int      `sql:"userId,pk"`
+	Email     string   `sql:"email,notnull"`
+	Activated bool     `sql:"activated,notnull"`
+	Name      *string  `sql:"name"`
+	CountryID *int     `sql:"countryId"`
+	Avatar    []byte   `sql:"avatar,notnull"`
+	AvatarAlt []byte   `sql:"avatarAlt"`
+	ApiKeys   [][]byte `sql:"apiKeys,array"`
 
 	Country *GeoCountry `pg:"fk:countryId"`
 }

--- a/generators/search/generator_test.go
+++ b/generators/search/generator_test.go
@@ -34,7 +34,7 @@ func TestGenerator_Generate(t *testing.T) {
 	}
 
 	if string(generated) != string(check) {
-		t.Errorf("generated not mathed with check")
+		t.Errorf("generated does not match with check")
 		return
 	}
 }

--- a/generators/search/generator_test.output
+++ b/generators/search/generator_test.output
@@ -82,6 +82,8 @@ type UserSearch struct {
 	Activated *bool
 	Name      *string
 	CountryID *int
+	Avatar    *[]byte
+	AvatarAlt *[]byte
 }
 
 func (s *UserSearch) Apply(query *orm.Query) *orm.Query {
@@ -99,6 +101,12 @@ func (s *UserSearch) Apply(query *orm.Query) *orm.Query {
 	}
 	if s.CountryID != nil {
 		s.where(query, Tables.User.Alias, Columns.User.CountryID, s.CountryID)
+	}
+	if s.Avatar != nil {
+		s.where(query, Tables.User.Alias, Columns.User.Avatar, s.Avatar)
+	}
+	if s.AvatarAlt != nil {
+		s.where(query, Tables.User.Alias, Columns.User.AvatarAlt, s.AvatarAlt)
 	}
 
 	s.apply(query)

--- a/generators/validate/generator_test.go
+++ b/generators/validate/generator_test.go
@@ -33,7 +33,7 @@ func TestGenerator_Generate(t *testing.T) {
 	}
 
 	if string(generated) != string(check) {
-		t.Errorf("generated not mathed with check")
+		t.Errorf("generated does not match with check")
 		return
 	}
 }

--- a/lib/store_test.go
+++ b/lib/store_test.go
@@ -330,8 +330,8 @@ func Test_store_Columns(t *testing.T) {
 			return
 		}
 
-		if ln := len(columns); ln != 7 {
-			t.Errorf("len(Store.Columns()) = %v, want %v", ln, 7)
+		if ln := len(columns); ln != 10 {
+			t.Errorf("len(Store.Columns()) = %v, want %v", ln, 10)
 			return
 		}
 	})

--- a/model/column.go
+++ b/model/column.go
@@ -33,8 +33,6 @@ type Column struct {
 func NewColumn(pgName string, pgType string, nullable, sqlNulls, array bool, dims int, pk, fk bool, len int, values []string, goPGVer int) Column {
 	var err error
 
-	array, dims = fixIsArray(pgType, array, dims)
-
 	column := Column{
 		PGName:     pgName,
 		PGType:     pgType,

--- a/model/types.go
+++ b/model/types.go
@@ -66,8 +66,8 @@ const (
 	TypeFloat64 = "float64"
 	// TypeString is a go type
 	TypeString = "string"
-	// TypeByte is a go type
-	TypeByte = "byte"
+	// TypeByteSlice is a go type
+	TypeByteSlice = "[]byte"
 	// TypeBool is a go type
 	TypeBool = "bool"
 	// TypeTime is a go type
@@ -87,14 +87,6 @@ const (
 	TypeInterface = "interface{}"
 )
 
-func fixIsArray(pgType string, isArray bool, dimensions int) (bool, int) {
-	if pgType == TypePGBytea {
-		return true, dimensions + 1
-	}
-
-	return isArray, dimensions
-}
-
 // GoType generates simple go type from pg type
 func GoType(pgType string) (string, error) {
 	switch pgType {
@@ -109,7 +101,7 @@ func GoType(pgType string) (string, error) {
 	case TypePGText, TypePGVarchar, TypePGUuid, TypePGBpchar, TypePGPoint:
 		return TypeString, nil
 	case TypePGBytea:
-		return TypeByte, nil
+		return TypeByteSlice, nil
 	case TypePGBool:
 		return TypeBool, nil
 	case TypePGTimestamp, TypePGTimestamptz, TypePGDate, TypePGTime, TypePGTimetz:
@@ -173,8 +165,8 @@ func GoNullable(pgType string, useSQLNull bool) (string, error) {
 	}
 
 	switch pgType {
-	case TypePGHstore, TypePGJSON, TypePGJSONB:
-		// hstore & json types without pointers
+	case TypePGHstore, TypePGJSON, TypePGJSONB, TypePGBytea:
+		// hstore & json & bytea types without pointers
 		return typ, nil
 	default:
 		return fmt.Sprintf("*%s", typ), nil

--- a/model/types_test.go
+++ b/model/types_test.go
@@ -45,7 +45,7 @@ func Test_goType(t *testing.T) {
 		{
 			name:    "Should get byte",
 			pgTypes: []string{TypePGBytea},
-			want:    TypeByte,
+			want:    TypeByteSlice,
 		},
 		{
 			name:    "Should get bool",
@@ -482,62 +482,6 @@ func Test_goImport(t *testing.T) {
 				if got := GoImport(pgType, tt.args.nullable, tt.args.avoidPointers, tt.args.ver); got != tt.want {
 					t.Errorf("GoImport() = %v, want %v", got, tt.want)
 				}
-			}
-		})
-	}
-}
-
-func Test_fixIsArray(t *testing.T) {
-	type args struct {
-		pgType     string
-		isArray    bool
-		dimensions int
-	}
-	tests := []struct {
-		name  string
-		args  args
-		want  bool
-		want1 int
-	}{
-		{
-			name: "Should fix array for Bytea type",
-			args: args{
-				pgType:     TypePGBytea,
-				isArray:    false,
-				dimensions: 0,
-			},
-			want:  true,
-			want1: 1,
-		},
-		{
-			name: "Should fix array for Bytea array type",
-			args: args{
-				pgType:     TypePGBytea,
-				isArray:    true,
-				dimensions: 1,
-			},
-			want:  true,
-			want1: 2,
-		},
-		{
-			name: "Should not fix type",
-			args: args{
-				pgType:     TypeInt,
-				isArray:    false,
-				dimensions: 0,
-			},
-			want:  false,
-			want1: 0,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := fixIsArray(tt.args.pgType, tt.args.isArray, tt.args.dimensions)
-			if got != tt.want {
-				t.Errorf("fixIsArray() got = %v, want %v", got, tt.want)
-			}
-			if got1 != tt.want1 {
-				t.Errorf("fixIsArray() got1 = %v, want %v", got1, tt.want1)
 			}
 		})
 	}

--- a/model/types_test.go
+++ b/model/types_test.go
@@ -384,7 +384,7 @@ func Test_goImport(t *testing.T) {
 			name: "Should not generate import for unknown type",
 			args: args{
 				pgTypes: []string{"unknown"},
-				ver: 8,
+				ver:     8,
 			},
 			want: "",
 		},
@@ -392,7 +392,7 @@ func Test_goImport(t *testing.T) {
 			name: "Should generate time import for interval type",
 			args: args{
 				pgTypes: []string{TypePGInterval},
-				ver: 8,
+				ver:     8,
 			},
 			want: "time",
 		},
@@ -422,7 +422,7 @@ func Test_goImport(t *testing.T) {
 				pgTypes: []string{
 					TypePGInt2, TypePGInt4, TypePGInt8, TypePGNumeric, TypePGFloat4, TypePGFloat8, TypePGBool, TypePGText, TypePGVarchar, TypePGUuid, TypePGBpchar,
 				},
-				ver: 8,
+				ver:           8,
 				nullable:      true,
 				avoidPointers: true,
 			},
@@ -434,7 +434,7 @@ func Test_goImport(t *testing.T) {
 				pgTypes: []string{
 					TypePGInt2, TypePGInt4, TypePGInt8, TypePGNumeric, TypePGFloat4, TypePGFloat8, TypePGBool, TypePGText, TypePGVarchar, TypePGUuid, TypePGBpchar,
 				},
-				ver: 8,
+				ver:           8,
 				nullable:      true,
 				avoidPointers: false,
 			},
@@ -446,7 +446,7 @@ func Test_goImport(t *testing.T) {
 				pgTypes: []string{
 					TypePGTimestamp, TypePGTimestamptz, TypePGDate, TypePGTime, TypePGTimetz,
 				},
-				ver: 8,
+				ver:      8,
 				nullable: true,
 			},
 			want: "time",
@@ -457,7 +457,7 @@ func Test_goImport(t *testing.T) {
 				pgTypes: []string{
 					TypePGTimestamp, TypePGTimestamptz, TypePGDate, TypePGTime, TypePGTimetz,
 				},
-				ver: 8,
+				ver:           8,
 				nullable:      true,
 				avoidPointers: true,
 			},
@@ -469,7 +469,7 @@ func Test_goImport(t *testing.T) {
 				pgTypes: []string{
 					TypePGTimestamp, TypePGTimestamptz, TypePGDate, TypePGTime, TypePGTimetz,
 				},
-				ver: 9,
+				ver:           9,
 				nullable:      true,
 				avoidPointers: true,
 			},

--- a/test_db.sql
+++ b/test_db.sql
@@ -18,6 +18,9 @@ create table "users"
     "activated" bool        not null default false,
     "name"      varchar(128),
     "countryId" integer,
+    "avatar"    bytea       not null,
+    "avatarAlt" bytea,
+    "apiKeys"   bytea[],
 
     primary key ("userId")
 );


### PR DESCRIPTION
# Problem

Assume:
```sql
CREATE TABLE test
(
  id      SERIAL PRIMARY KEY,
  data    BYTEA,
  bigdata BYTEA[]
);
```

The generated model is:
```go
type Test struct {
	tableName struct{} `pg:"test,alias:t,,discard_unknown_columns"`

	ID      int      `pg:"id,pk"`
	Data    []byte   `pg:"data,array"`
	Bigdata [][]byte `pg:"bigdata,array"`
}
```

Notice the `array` tag is present in both columns. However, only `bigdata` is a real Postgres Array.  
The result of `data` also being tagged with `array`, is that go-pg serializes it to the [array representation](https://www.postgresql.org/docs/current/arrays.html#ARRAYS-INPUT), this representation itself is then stored into the `BYTEA`.  

Example:
```go
db.Insert(Test{
	Data: []byte{0x00},
})
```
Postgres stores this:
```sql
test=> select * from test;
 id |   data   | bigdata 
----+----------+---------
  1 | \x7b307d | 
(1 row)
```
`0x7b307d` is ASCII for `{0}`

Besides from being simply wrong, this is vastly inefficent (x2-3 overhead) and it also breaks the go-pg `query.Where` (this is how I noticed it).

# Proposed Solution

The PR changes how `model.TypePGBytea` is mapped internally.  
It now directly maps it to `model.TypeByteSlice` and only sets `model.Column.IsArray` if the column is a Postgres Array.  

This eliminates `fixIsArray`, and I believe it is more understandable.  
I also changed some minor nullable fixes.

I verfied that it works for the model / named generator.  
I am not familiar with other ones, but reading through the code it looks okay.  
Unit tests pass, except `search/generator_test.go`, but that is not my fault.

Maybe I am missing something, since there was a `fixIsArray` in the first place, let me know :P 

Cheers,
m1ckey