### PR TITLE
add missing flag & fix error

### DIFF
--- a/generators/search/generator.go
+++ b/generators/search/generator.go
@@ -50,6 +50,8 @@ func (g *Search) AddFlags(command *cobra.Command) {
 	flags.BoolP(noAlias, "w", false, `do not set 'alias' tag to "t"`)
 
 	flags.BoolP(relaxed, "r", false, "use interface{} type in search filters\n")
+
+	flags.Bool(jsonTag, false, "add json tag to annotations")
 }
 
 // ReadFlags read flags from command


### PR DESCRIPTION
At the moment `genna search` produces the following error:
```
$ genna search ..<args>..
2021/10/14 16:45:22 read flags error: flag accessed but not defined: json-tag
```

This patch fixes it.